### PR TITLE
Make Get-ExternalTools dl in releng/ if run in root

### DIFF
--- a/releng/Get-ExternalTools.ps1
+++ b/releng/Get-ExternalTools.ps1
@@ -1,11 +1,15 @@
+$WasRootDir = (Get-Item .).Name -ne "releng"
+if ($WasRootDir) {
+    Set-Location -Path releng
+}
+
 $Url = "https://github.com/lexxmark/winflexbison/releases/download/v2.5.17/winflexbison-2.5.17.zip"
 $ExpectedHash = "3DC27A16C21B717BCC5DE8590B564D4392A0B8577170C058729D067D95DED825"
 
 [IO.Directory]::CreateDirectory('external\tools\bin') | Out-Null
 Invoke-WebRequest -UseBasicParsing $Url -OutFile 'winflexbison.zip'
 $Results = Get-FileHash 'winflexbison.zip' -Algorithm SHA256
-if($Results.Hash -ne $ExpectedHash)
-{
+if ($Results.Hash -ne $ExpectedHash) {
     Write-Output "Expected hash: $ExpectedHash"
     Write-Output "Actual hash  : $($Results.Hash)"
     Write-Error "Downloaded file hash does not match expected hash"
@@ -13,3 +17,7 @@ if($Results.Hash -ne $ExpectedHash)
 
 Expand-Archive -Path 'winflexbison.zip' -DestinationPath 'external\tools\bin' -Force
 Remove-Item 'winflexbison.zip'
+
+if ($WasRootDir) {
+    Set-Location -Path ..
+}


### PR DESCRIPTION
I spent a while debugging why my build was not working. I had run `releng/Get-ExternalTools.ps1` from the root of the repo, and all VS was giving in the build output was `The system cannot find the path specified.`

This small change makes that script download into releng/external even if run from the root directory