### PR TITLE
Decrement g_pslive when a targeted process exits

### DIFF
--- a/cmd/dtrace.c
+++ b/cmd/dtrace.c
@@ -875,6 +875,7 @@ prochandler(struct ps_prochandle *P, const char *msg, void *arg)
 	} else {
 		notice("pid %d has exited\n", pid);
 	}
+	g_pslive--;
 #else
 
 #ifdef illumos


### PR DESCRIPTION
Fixes https://github.com/microsoft/DTrace-on-Windows/issues/4